### PR TITLE
added dir support, added toString()

### DIFF
--- a/lib/mode-to-permissions.js
+++ b/lib/mode-to-permissions.js
@@ -10,7 +10,8 @@ module.exports = function (mode) {
       group = (mode << 3) >> 6,
       others = (mode << 6) >> 6;
 
-  return {
+  var result = {
+    dir: !!(mode & 0x04000),
     read: {
       owner: !!(owner & 4),
       group: !!(group & 4),
@@ -27,4 +28,22 @@ module.exports = function (mode) {
       others: !!(others & 1)
     }
   };
+
+  return Object.defineProperty(result,'toString',{
+    enumerable  : false,
+    writable    : false,
+    configurable: false,
+    value       : function() {
+      return (result.dir          ? 'd' : '-')
+        + (result.read    .owner  ? 'r' : '-')
+        + (result.write   .owner  ? 'w' : '-')
+        + (result.execute .owner  ? 'x' : '-')
+        + (result.read    .group  ? 'r' : '-')
+        + (result.write   .group  ? 'w' : '-')
+        + (result.execute .group  ? 'x' : '-')
+        + (result.read    .others ? 'r' : '-')
+        + (result.write   .others ? 'w' : '-')
+        + (result.execute .others ? 'x' : '-')
+      }
+  });
 };

--- a/test/mode-to-permissions-test.js
+++ b/test/mode-to-permissions-test.js
@@ -2,13 +2,22 @@ var assert = require('assert'),
     m = require('../');
 
 assert.deepEqual(m(0777), {
+  dir: false,
   read: { owner: true, group: true, others: true },
   write: { owner: true, group: true, others: true },
   execute: { owner: true, group: true, others: true }
 });
+assert.equal(m(0777),'-rwxrwxrwx')
 
 assert.deepEqual(m(0071), {
+  dir: false,
   read: { owner: false, group: true, others: false },
   write: { owner: false, group: true, others: false },
   execute: { owner: false, group: true, others: true }
 });
+assert.equal(m(0071),'----rwx--x')
+
+var fs = require('fs');
+var mode = fs.statSync('.');
+assert.equal(true,m(mode).dir);
+assert.equal('d',m(mode).toString().charAt(0));


### PR DESCRIPTION
Hi @mmalecki!
Thanks for this useful module!

I needed support for directories and for character representations (eg `-rwx-rw-rw`), so I added a `dir` flag and `toString()` method, including tests.

I hope you like the improvements :) Would you care to merge?

Thanks!

A.
